### PR TITLE
environment variables inside docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
     ports:
       - 7000:5432
     environment:
-      POSTGRES_DB: guideappdb
-      POSTGRES_USER: guideappuser
-      POSTGRES_PASSWORD: guideapp
+      POSTGRES_DB: "${DATABASE_NAME}"
+      POSTGRES_USER: "${DATABASE_USERNAME}"
+      POSTGRES_PASSWORD: "${DATABASE_PASSWORD}"
     volumes:
       - ./.dataPg:/var/lib/postgresql/data  
 


### PR DESCRIPTION
A bug was found in the environment variables in the docker-compose file, representing a security problem